### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![License](http://img.shields.io/:license-mit-blue.svg)](LICENSE)
 
 
-##IOS7 风格的Switch开关  
-###IOS7 Style Switch Widget
+## IOS7 风格的Switch开关  
+### IOS7 Style Switch Widget
 *****
 
 
@@ -21,8 +21,8 @@
 
 
 
-##添加到你的项目中
-###add to your project
+## 添加到你的项目中
+### add to your project
 *****
 
 在gradle脚本的dependencies中加入
@@ -35,8 +35,8 @@ compile 'com.7heaven.ioswidget:iosswitch:0.6'
 
 
 
-##使用
-###usage
+## 使用
+### usage
 *****
 
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
